### PR TITLE
ci(deploy): 修改邮件发送地址

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,7 +66,7 @@ jobs:
             状态: ${{ github.event.workflow_run.conclusion }}
             日志链接: ${{ github.event.workflow_run.html_url }}
           to: a17674328693@gmail.com # 收件邮箱
-          from: GitHub Actions <actions@github.com>
+          from: ${{secrets.SMTP_USER}}
           content_type: text/plain
 
       - name: Move built files to root directory and clean up


### PR DESCRIPTION
- 将邮件发送方地址从固定的 GitHub Actions 地址改为使用 secrets.SMTP_USER 环境变量
- 这样可以使用项目配置的 SMTP_USER，提高灵活性和安全性