### PR TITLE
ci(deploy): 启用 SSL 加密发送构建日志邮件

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,6 +67,7 @@ jobs:
             日志链接: ${{ github.event.workflow_run.html_url }}
           to: yangjunmi@foxmail.com # 收件邮箱
           from: yt8766M@gmail.com
+          secure: true # 启用 SSL 加密 secure: true  # 启用 SSL 加密
           content_type: text/plain
 
       - name: Move built files to root directory and clean up


### PR DESCRIPTION
- 在 GitHub Actions 的 deploy.yml 文件中添加 secure: true 配置
- 此修改提高了邮件传输的安全性，确保构建日志在发送过程中得到加密