### PR TITLE
ci(deploy): 更新邮箱通知接收人列表

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,7 +65,7 @@ jobs:
             构建工作流: ${{ github.event.workflow_run.name }}
             状态: ${{ github.event.workflow_run.conclusion }}
             日志链接: ${{ github.event.workflow_run.html_url }}
-          to: a17674328693@gmail.com # 收件邮箱
+          to: a17674328693@gmail.com,1322147900@qq.com # 收件邮箱
           from: yangjunmi@foxmail.com
           secure: true
 


### PR DESCRIPTION
- 在 GitHub Actions 的 deploy 工作流中，更新了邮箱通知的接收人列表
- 新增了 1322147900@qq.com 作为收件邮箱，与原有的 a17674328693@gmail.com 一起接收通知