### PR TITLE
ci(deploy): 更新邮件通知配置

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,7 +69,7 @@ jobs:
             提交ID: ${{ github.sha }}
             构建状态: ${{ job.status  }}
             日志: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          to: a17674328693@gmail.com,1322147900@qq.com # 收件邮箱
+          to: ${{secrets.MAIL_TO}} # 收件邮箱
           from: ${{secrets.MAIL_USERNAME }}
           secure: true
 


### PR DESCRIPTION
- 将收件邮箱地址从硬编码改为使用 GitHub Secrets 中的 MAIL_TO 变量
- 提高了配置的灵活性和安全性